### PR TITLE
handle babel.transform errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,15 +22,20 @@ function es2020 (filename, options) {
 
   function end () {
     const src = Buffer.concat(bufs).toString('utf8')
-    const res = babel.transform(src, {
-      plugins: [
-        checkConstants,
-        templateLiterals,
-        arrowFunctions,
-        blockScoping
-      ],
-      sourceMaps: options._flags.debug ? 'inline' : false
-    })
+    try {
+      var res = babel.transform(src, {
+        plugins: [
+          checkConstants,
+          templateLiterals,
+          arrowFunctions,
+          blockScoping
+        ],
+        sourceMaps: options._flags.debug ? 'inline' : false
+      })
+    } catch (err) {
+      this.emit('error', err)
+      return
+    }
     this.push(res.code)
     this.push(null)
   }

--- a/test.js
+++ b/test.js
@@ -40,3 +40,16 @@ test('source maps', function (t) {
     t.equal(original, fs.readFileSync(path.resolve(__dirname, 'example.js'), 'utf8'))
   })
 })
+
+test('handle errors', function (t) {
+  t.plan(1)
+
+  browserify({
+    debug: true
+  })
+  .add('LICENSE')
+  .transform(es2020)
+  .bundle(function (err, code) {
+    t.ok(err, 'handles error')
+  })
+})


### PR DESCRIPTION
hey cats,

this pull request uses [code from `babelify`](https://github.com/babel/babelify/blob/6997ff5bec307269978545e5295b46fc9f399f42/index.js#L25-L36) to handle `babel.transform` errors appropriately.

without this change, the error is thrown outside of the browserify stream, so is never handled properly, which is particularly bad when you want to use this transform with `watchify`.
