### PR TITLE
deps: use es2020 preset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 node_js:
-- "0.12"
 - "4"
+- "6"
 sudo: false
 language: node_js
 script: "npm run test:cov"

--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
+const preset = require('babel-preset-es2020')
 const through = require('through2')
 const babel = require('babel-core')
-
-const templateLiterals = require('babel-plugin-transform-es2015-template-literals')
-const arrowFunctions = require('babel-plugin-transform-es2015-arrow-functions')
-const blockScoping = require('babel-plugin-transform-es2015-block-scoping')
-const checkConstants = require('babel-plugin-check-es2015-constants')
 
 module.exports = es2020
 
@@ -24,12 +20,7 @@ function es2020 (filename, options) {
     const src = Buffer.concat(bufs).toString('utf8')
     try {
       var res = babel.transform(src, {
-        plugins: [
-          checkConstants,
-          templateLiterals,
-          arrowFunctions,
-          blockScoping
-        ],
+        plugins: preset.plugins,
         sourceMaps: options._flags.debug ? 'inline' : false
       })
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-core": "^6.9.0",
-    "babel-plugin-check-es2015-constants": "^6.8.0",
-    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-    "babel-plugin-transform-es2015-block-scoping": "^6.9.0",
-    "babel-plugin-transform-es2015-template-literals": "^6.8.0",
+    "babel-preset-es2020": "^1.0.2",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Uses `babel-preset-es2020` preset. Should make it easier to create derivative packages. Thanks!
