### PR TITLE
Pass JSON files through

### DIFF
--- a/example.json
+++ b/example.json
@@ -1,0 +1,1 @@
+{ "same": "as it ever was" }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = es2020
 // In hindsight we can do without most of ES6
 // (str, obj) -> transformStream
 function es2020 (filename, options) {
+  if (/\.json$/i.test(filename)) return through()
   const bufs = []
   const transformStream = through(write, end)
   return transformStream

--- a/test.js
+++ b/test.js
@@ -45,6 +45,21 @@ test('source maps', function (t) {
   })
 })
 
+test('JSON files', function (t) {
+  t.plan(2)
+
+  browserify()
+    .add('example.json')
+    .transform(es2020)
+    .bundle(function (err, code) {
+      if (err) return t.end(err)
+      code = String(code)
+
+      t.assert(code.includes('same'), 'preserves key')
+      t.assert(code.includes('as it ever was'), 'preserves value')
+    })
+})
+
 test('handle errors', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
Long time, no see!

Plugging es2020 into the Browserify chain currently creates "Unexpected token" errors on code that `require()`s JSON files.

This tiny PR:
1. Adds a test for this unfortunate situation.
2. Checks filenames coming in and passes `.json` files through without transformation. (`through2` without arguments creates a pass-through stream.)

Thanks for this package!

Best,

K
